### PR TITLE
Flatten import hierarchy

### DIFF
--- a/src/CollectSources.swift
+++ b/src/CollectSources.swift
@@ -15,12 +15,13 @@ import Foundation
 /**
  * This function resolves wildcards in source descriptions to complete values
  *   - parameter sourceDescriptions: a descriptions of sources such as ["src/**.swift"] */
+ *   - parameter taskForCalculatingPath: A task relative to which we calculate the path (to handle the import case).  If nil, we return what is listed in the atpkg.
  *   - returns: A list of resolved sources such as ["src/a.swift", "src/b.swift"]
  */
-public func collectSources(sourceDescriptions: [String], task: Task) -> [String] {
+public func collectSources(sourceDescriptions: [String], taskForCalculatingPath task: Task?) -> [String] {
     var sources : [String] = []
     for unPrefixedDescription in sourceDescriptions {
-        let description = task.importedPath + unPrefixedDescription
+        let description = (task?.importedPath ?? "") + unPrefixedDescription
         if description.hasSuffix("**.swift") {
             let basepath = String(Array(description.characters)[0..<description.characters.count - 9])
             let manager = NSFileManager.defaultManager()

--- a/src/Package.swift
+++ b/src/Package.swift
@@ -159,7 +159,7 @@ final public class Package {
         if let dependencies = task["dependencies"]?.vector {
             for next in dependencies {
                 guard let depName = next.string else { fatalError("Non-string dependency \(next)")}
-                guard let nextTask = tasks[depName] else { fatalError("Can't find so-called task \(depName)")}
+                guard let nextTask = task.package.tasks[depName] else { fatalError("Can't find so-called task \(depName)")}
                 let nextGraph = prunedDependencyGraph(nextTask)
                 for nextItem in nextGraph {
                     let filteredTasks = pruned.filter() {$0.qualifiedName == nextItem.qualifiedName}

--- a/src/Package.swift
+++ b/src/Package.swift
@@ -292,7 +292,7 @@ final public class Package {
         //load remote tasks
         for remotePackage in remotePackages {
             for (_, task) in remotePackage.tasks {
-                task.importedPath = remotePackage.adjustedImportPath
+                task.importedPath = task.package.adjustedImportPath
                 self.tasks[task.qualifiedName] = task
             }
         }

--- a/src/Package.swift
+++ b/src/Package.swift
@@ -149,6 +149,8 @@ final public class Package {
     appear only by qualified name. */
     public var tasks: [String:Task] = [:]
 
+    public var importedPath: String
+
     var overlays: [String: [String: ParseValue]] = [:]
     var adjustedImportPath: String = ""
 
@@ -172,10 +174,6 @@ final public class Package {
         return pruned
     }
     
-    public init(name: String) {
-        self.name = name
-    }
-    
     /**Create the package.
 - parameter filepath: The path to the file to load
 - parameter overlay: A list of overlays to apply globally to all tasks in the package. */
@@ -194,8 +192,9 @@ final public class Package {
     }
     
     public init?(type: ParseType, overlay requestedGlobalOverlays: [String], pathOnDisk: String) {
+        self.importedPath = pathOnDisk
+
         if type.name != "package" { return nil }
-        
         if let value = type.properties["name"]?.string { self.name = value }
         else {
             print("ERROR: No name specified for the package.")

--- a/tests/collateral/chained_import_overlays/a.atpkg
+++ b/tests/collateral/chained_import_overlays/a.atpkg
@@ -1,0 +1,12 @@
+(package
+  :name "a"
+  :import ["b.atpkg"]
+
+  :tasks {
+    :default {
+        :dependencies ["b.default"]
+        :name "a_default"
+        :overlay ["c.foo"]
+    }
+  }
+)

--- a/tests/collateral/chained_import_overlays/b.atpkg
+++ b/tests/collateral/chained_import_overlays/b.atpkg
@@ -1,0 +1,11 @@
+(package
+  :name "b"
+  :import ["c.atpkg"]
+
+  :tasks {
+    :default {
+        :dependencies ["c.default" "foo"]
+        :name "b_default"
+    }
+  }
+)

--- a/tests/collateral/chained_import_overlays/c.atpkg
+++ b/tests/collateral/chained_import_overlays/c.atpkg
@@ -1,0 +1,15 @@
+(package
+  :name "c"
+
+  :overlays {
+    :foo {
+        :compileOptions ["foo"]
+    }
+  }
+  
+  :tasks {
+    :default {
+        :name "c_default"
+    }
+  }
+)

--- a/tests/collateral/chained_imports/a.atpkg
+++ b/tests/collateral/chained_imports/a.atpkg
@@ -1,0 +1,11 @@
+(package
+  :name "a"
+  :import ["b.atpkg"]
+
+  :tasks {
+    :default {
+        :dependencies ["b.default"]
+        :name "a_default"
+    }
+  }
+)

--- a/tests/collateral/chained_imports/b.atpkg
+++ b/tests/collateral/chained_imports/b.atpkg
@@ -3,8 +3,11 @@
   :import ["c.atpkg"]
 
   :tasks {
+    :foo {
+
+    }
     :default {
-        :dependencies ["c.default"]
+        :dependencies ["c.default" "foo"]
         :name "b_default"
     }
   }

--- a/tests/collateral/chained_imports/b.atpkg
+++ b/tests/collateral/chained_imports/b.atpkg
@@ -1,0 +1,11 @@
+(package
+  :name "b"
+  :import ["c.atpkg"]
+
+  :tasks {
+    :default {
+        :dependencies ["c.default"]
+        :name "b_default"
+    }
+  }
+)

--- a/tests/collateral/chained_imports/c.atpkg
+++ b/tests/collateral/chained_imports/c.atpkg
@@ -1,0 +1,9 @@
+(package
+  :name "c"
+  
+  :tasks {
+    :default {
+        :name "c_default"
+    }
+  }
+)

--- a/tests/collateral/import_paths/a.atpkg
+++ b/tests/collateral/import_paths/a.atpkg
@@ -1,0 +1,11 @@
+(package
+  :name "a"
+  :import ["b/b.atpkg"]
+
+  :tasks {
+    :default {
+        :dependencies ["b.default"]
+        :name "a_default"
+    }
+  }
+)

--- a/tests/collateral/import_paths/b/b.atpkg
+++ b/tests/collateral/import_paths/b/b.atpkg
@@ -1,0 +1,14 @@
+(package
+  :name "b"
+  :import ["c/c.atpkg"]
+
+  :tasks {
+    :foo {
+
+    }
+    :default {
+        :dependencies ["c.default" "foo"]
+        :name "b_default"
+    }
+  }
+)

--- a/tests/collateral/import_paths/b/c/c.atpkg
+++ b/tests/collateral/import_paths/b/c/c.atpkg
@@ -1,0 +1,9 @@
+(package
+  :name "c"
+  
+  :tasks {
+    :default {
+        :name "c_default"
+    }
+  }
+)

--- a/tests/model/PackageTests.swift
+++ b/tests/model/PackageTests.swift
@@ -161,5 +161,9 @@ class PackageTests: Test {
             fatalError("No default task in c")
         }
         try test.assert(c_default_qualified["name"]?.string == "c_default")
+
+        //check package dependency graph
+        let _ = package.prunedDependencyGraph(a_default_unqualified)
+        
     }
 }

--- a/tests/model/PackageTests.swift
+++ b/tests/model/PackageTests.swift
@@ -23,7 +23,8 @@ class PackageTests: Test {
         PackageTests.testImport,
         PackageTests.testOverlays,
         PackageTests.testExportedOverlays,
-        PackageTests.testChainedImports
+        PackageTests.testChainedImports,
+        PackageTests.testImportPaths
     ]
 
     let filename = __FILE__
@@ -165,5 +166,40 @@ class PackageTests: Test {
         //check package dependency graph
         let _ = package.prunedDependencyGraph(a_default_unqualified)
         
+    }
+
+    static func testImportPaths () throws {
+        let filepath = "./tests/collateral/import_paths/a.atpkg"
+        guard let package = Package(filepath: filepath, overlay: []) else { print("error"); try test.assert(false); return }
+        guard let a_default_unqualified = package.tasks["default"] else {
+            fatalError("No default task")
+        }
+        try test.assert(a_default_unqualified["name"]?.string == "a_default")
+
+        guard let a_default_qualified = package.tasks["a.default"] else {
+            fatalError("No default task (qualified)")
+        }
+        try test.assert(a_default_qualified["name"]?.string == "a_default")
+
+        guard let b_default_qualified = package.tasks["b.default"] else {
+            fatalError("No default task in b")
+        }
+        try test.assert(b_default_qualified["name"]?.string == "b_default")
+
+        guard let c_default_qualified = package.tasks["c.default"] else {
+            fatalError("No default task in c")
+        }
+        try test.assert(c_default_qualified["name"]?.string == "c_default")
+
+        //check package dependency graph
+        let _ = package.prunedDependencyGraph(a_default_unqualified)
+
+        //check each import path
+        try test.assert(a_default_unqualified.importedPath == "./tests/collateral/import_paths/")
+        try test.assert(a_default_qualified.importedPath == "./tests/collateral/import_paths/")
+        try test.assert(b_default_qualified.importedPath == "./tests/collateral/import_paths/b/")
+        try test.assert(c_default_qualified.importedPath == "./tests/collateral/import_paths/b/c/")
+
+
     }
 }


### PR DESCRIPTION
Note: this should be merged simultaneously with `atbuild:flatten_imports`

We import all packages in a flat hierarchy, with the package name, a
period, and the task.

Using a flat heirarchy eliminates the case where a/b/c != a/d/c.

As a side effect, this closes #4
