### PR TITLE
Mute warnings

### DIFF
--- a/src/Package.swift
+++ b/src/Package.swift
@@ -147,19 +147,26 @@ final public class Package {
     }
     
     /**Create the package.
-- parameter filepath: The path to the file to load
-- parameter overlay: A list of overlays to apply globally to all tasks in the package. */
-    public convenience init(filepath: String, overlay: [String]) throws {
+    - parameter pathOnDisk: The path to the file on disk.  This does not include the file name.
+    - parameter overlay: A list of overlays to apply globally to all tasks in the package.
+    - parameter focusOnTask: The user has "selected" the particular task.  We provide more diagnostics for this task.
+*/
+    public convenience init(filepath: String, overlay: [String], focusOnTask: String?) throws {
 
         //todo: why doesn't this throw?
         guard let parser = Parser(filepath: filepath) else { throw PackageError.ParserFailed }
         
         let result = try parser.parse()
         let basepath = filepath.toNSString.stringByDeletingLastPathComponent
-        try self.init(type: result, overlay: overlay, pathOnDisk:basepath)
+        try self.init(type: result, overlay: overlay, pathOnDisk:basepath, focusOnTask: focusOnTask)
     }
     
-    public init(type: ParseType, overlay requestedGlobalOverlays: [String], pathOnDisk: String) throws {
+    /**
+    - parameter overlay: The names of things to overlay.
+    - parameter pathOnDisk: The path to the file on disk.  This does not include the file name.
+    - parameter focusOnTask: The user has "selected" the particular task.  We provide more diagnostics for this task.
+    */
+    public init(type: ParseType, overlay requestedGlobalOverlays: [String], pathOnDisk: String, focusOnTask: String?) throws {
         //warn on unknown keys
         for (k,_) in type.properties {
             if !Key.allKeys.map({$0.rawValue}).contains(k) {
@@ -196,7 +203,7 @@ final public class Package {
                 guard let importFileString = importFile.string else { fatalError("Non-string import \(importFile)")}
                 let adjustedImportPath = (pathOnDisk.pathWithTrailingSlash + importFileString).toNSString.stringByDeletingLastPathComponent.pathWithTrailingSlash
                 let adjustedFileName = importFileString.toNSString.lastPathComponent
-                let remotePackage = try Package(filepath: adjustedImportPath + adjustedFileName, overlay: requestedGlobalOverlays)
+                let remotePackage = try Package(filepath: adjustedImportPath + adjustedFileName, overlay: requestedGlobalOverlays, focusOnTask: nil)
                 remotePackage.adjustedImportPath = adjustedImportPath
                 remotePackages.append(remotePackage)
             }
@@ -227,6 +234,7 @@ final public class Package {
         var usedGlobalOverlays : [String] = []
         //swap in overlays
 
+        var warnings: [String] = []
         while true {
             var again = false
             for (_, task) in self.tasks {
@@ -250,7 +258,11 @@ final public class Package {
                     if task.appliedOverlays.contains(overlayName) { continue }
 
                     guard let overlay = declaredOverlays[overlayName] else {
-                        print("Warning: Can't apply overlay \(overlayName) to task \(task.qualifiedName)")
+                        if focusOnTask == task.unqualifiedName || focusOnTask == task.qualifiedName {
+                            let proposedWarning = "Warning: Can't apply overlay \(overlayName) to task \(task.qualifiedName)"
+                            if !warnings.contains(proposedWarning) { warnings.append(proposedWarning) }
+
+                        }
                         continue
                     }
                     again = again || task.applyOverlay(overlayName, overlay: overlay)
@@ -258,6 +270,9 @@ final public class Package {
                 }
             }
             if !again { break }
+        }
+        for warning in warnings {
+            print(warning)
         }
 
         //warn about unused global overlays

--- a/tests/model/PackageTests.swift
+++ b/tests/model/PackageTests.swift
@@ -41,7 +41,7 @@ class PackageTests: Test {
         }
         
         let result = try parser.parse()
-        let package = try Package(type: result, overlay: [], pathOnDisk: "./tests/collateral")
+        let package = try Package(type: result, overlay: [], pathOnDisk: "./tests/collateral", focusOnTask: nil)
         
         try test.assert(package.name == "basic")
         try test.assert(package.version == "0.1.0-dev")
@@ -59,7 +59,7 @@ class PackageTests: Test {
 
     static func testImport() throws {
         let filepath = "./tests/collateral/import_src.atpkg"
-        let package = try Package(filepath: filepath, overlay: [])
+        let package = try Package(filepath: filepath, overlay: [], focusOnTask: nil)
 
         try test.assert(package.tasks["import_dst.build"] != nil)
         try test.assert(package.tasks["import_dst.build"]!.importedPath == "./tests/collateral/")
@@ -67,7 +67,7 @@ class PackageTests: Test {
 
     static func testOverlays() throws {
         let filepath = "./tests/collateral/overlays.atpkg"
-        let package = try Package(filepath: filepath, overlay: [])
+        let package = try Package(filepath: filepath, overlay: [], focusOnTask: nil)
         guard let compileOptions = package.tasks["build"]?["compile-options"]?.vector else {
             fatalError("No compile options?")
         }
@@ -75,7 +75,7 @@ class PackageTests: Test {
         try test.assert(compileOptions[0].string == "-D")
         try test.assert(compileOptions[1].string == "AWESOME")
 
-        let package2 = try Package(filepath: filepath, overlay: ["more-awesome"])
+        let package2 = try Package(filepath: filepath, overlay: ["more-awesome"], focusOnTask:nil)
         guard let compileOptions2 = package2.tasks["build"]?["compile-options"]?.vector else {
             fatalError("no compile options?")
         }
@@ -85,7 +85,7 @@ class PackageTests: Test {
         try test.assert(compileOptions2[2].string == "-D")
         try test.assert(compileOptions2[3].string == "MORE_AWESOME")
 
-        let package3 = try Package(filepath: filepath, overlay: ["most-taskspecific"])
+        let package3 = try Package(filepath: filepath, overlay: ["most-taskspecific"], focusOnTask: nil)
         guard let compileOptions3 = package3.tasks["build"]?["compile-options"]?.vector else {
             fatalError("no compile options?")
         }
@@ -95,7 +95,7 @@ class PackageTests: Test {
         try test.assert(compileOptions3[2].string == "-D")
         try test.assert(compileOptions3[3].string == "MOST_AWESOME")
 
-        let package4 = try Package(filepath: filepath, overlay: ["most-taskspecific-two"])
+        let package4 = try Package(filepath: filepath, overlay: ["most-taskspecific-two"], focusOnTask: nil)
         guard let compileOptions4 = package4.tasks["build"]?["compile-options"]?.vector else {
             fatalError("no compile options?")
         }
@@ -105,13 +105,13 @@ class PackageTests: Test {
         try test.assert(compileOptions4[2].string == "-D")
         try test.assert(compileOptions4[3].string == "MOST_AWESOME")
 
-        let package5 = try Package(filepath: filepath, overlay: ["string-option"])
+        let package5 = try Package(filepath: filepath, overlay: ["string-option"], focusOnTask: nil)
         guard let stringOption = package5.tasks["build"]?["string-option"]?.string else {
             fatalError("no string option?")
         }
         try test.assert(stringOption == "stringOption")
 
-        let package6 = try Package(filepath: filepath, overlay: ["empty-vec-option"])
+        let package6 = try Package(filepath: filepath, overlay: ["empty-vec-option"], focusOnTask: nil)
         guard let vecOption = package6.tasks["build"]?["empty-vec-option"]?.vector else {
             fatalError("no vec option?")
         }
@@ -119,7 +119,7 @@ class PackageTests: Test {
 
         try test.assert(vecOption[0].string == "OVERLAY")
 
-        let package7 = try Package(filepath: filepath, overlay: ["bool-option"])
+        let package7 = try Package(filepath: filepath, overlay: ["bool-option"], focusOnTask: nil)
         guard let boolOption = package7.tasks["build"]?["bool-option"]?.bool else {
             fatalError("no bool option?")
         }
@@ -129,7 +129,7 @@ class PackageTests: Test {
     static func testExportedOverlays() throws {
         let filepath = "./tests/collateral/overlays_src.atpkg"
 
-        let package2 = try Package(filepath: filepath, overlay: [])
+        let package2 = try Package(filepath: filepath, overlay: [], focusOnTask: nil)
         guard let compileOptions2 = package2.tasks["build"]?["compile-options"]?.vector else {
             fatalError("no compile options?")
         }
@@ -145,7 +145,7 @@ class PackageTests: Test {
 
     static func testChainedImports () throws {
         let filepath = "./tests/collateral/chained_imports/a.atpkg"
-        let package = try Package(filepath: filepath, overlay: [])
+        let package = try Package(filepath: filepath, overlay: [], focusOnTask: nil)
         guard let a_default_unqualified = package.tasks["default"] else {
             fatalError("No default task")
         }
@@ -173,7 +173,7 @@ class PackageTests: Test {
 
     static func testImportPaths () throws {
         let filepath = "./tests/collateral/import_paths/a.atpkg"
-        let package = try Package(filepath: filepath, overlay: [])
+        let package = try Package(filepath: filepath, overlay: [], focusOnTask: nil)
         guard let a_default_unqualified = package.tasks["default"] else {
             fatalError("No default task")
         }
@@ -206,7 +206,7 @@ class PackageTests: Test {
 
     static func testChainedImportOverlays() throws {
         let filepath = "./tests/collateral/chained_import_overlays/a.atpkg"
-        let package = try Package(filepath: filepath, overlay: ["b.foo"])
+        let package = try Package(filepath: filepath, overlay: ["b.foo"], focusOnTask: nil)
         guard let a_qualified = package.tasks["a.default"] else { print("error"); try test.assert(false); return }
         guard let options = a_qualified["compile-options"]?.vector else {
             fatalError("Invalid options vector")
@@ -221,14 +221,14 @@ class PackageTests: Test {
     static func testRequireOverlays() throws {
         let filepath = "./tests/collateral/require_overlays.atpkg"
         do {
-            let _ = try Package(filepath: filepath, overlay: [])
+            let _ = try Package(filepath: filepath, overlay: [], focusOnTask: nil)
             print("Overlays were not required")
             try test.assert(false)
         }
         catch {}
 
         do {
-            let _ = try Package(filepath: filepath, overlay: ["osx"]) 
+            let _ = try Package(filepath: filepath, overlay: ["osx"], focusOnTask: nil) 
         }
         catch {
             print("Overlays were provided")
@@ -239,7 +239,7 @@ class PackageTests: Test {
 
     static func nonVectorImport() throws {
         let filepath = "./tests/collateral/non_vector_import.atpkg"
-        if let _ = try? Package(filepath: filepath, overlay: []) {
+        if let _ = try? Package(filepath: filepath, overlay: [], focusOnTask: nil) {
             try test.assert(false) //no diagnostic
         }
     }


### PR DESCRIPTION
Merge with `atbuild:mute_warnings`

We have too many warnings; this patch silences some of them.
- Silencing a certain class of duplicate warnings.  We currently are quite conservative with continuing to process overlays until we are quite sure they are all applied; this produces duplicate warnings in common cases.  We now filter those before we print them.
- We have a new parameter `focusOnTask` which focuses some verbose warnings on the particular task, not everything in the package file.
