### PR TITLE
Revise required-overlays check

### DIFF
--- a/src/Package.swift
+++ b/src/Package.swift
@@ -331,28 +331,6 @@ final public class Package {
             }
         }
 
-        //error on required overlays
-        for (_, task) in self.tasks {
-            if let requiredOverlays_v = task["required-overlays"] {
-                guard let requiredOverlays = requiredOverlays_v.vector else {
-                    fatalError("Non-vector \(requiredOverlays_v)")
-                }
-                nextSet: for overlaySet_v in requiredOverlays {
-                    guard let overlaySet = overlaySet_v.vector else {
-                        fatalError("Non-vector \(overlaySet_v)")
-                    }
-                    for overlay_s in overlaySet {
-                        guard let overlay = overlay_s.string else {
-                            fatalError("Non-string \(overlay_s)")
-                        }
-                        if task.appliedOverlays.contains(overlay) { continue nextSet }
-                    }
-                    print("Task \(task.qualifiedName) requires at least one of \(overlaySet.map() {$0.string}) but it was not applied.  Applied overlays: \(task.appliedOverlays)")
-                    throw PackageError.RequiredOverlayNotPresent(overlaySet.map() {$0.string!})
-                }
-            }
-        }
-
         //load remote tasks
         for remotePackage in remotePackages {
             for (_, task) in remotePackage.tasks {

--- a/src/Task.swift
+++ b/src/Task.swift
@@ -107,4 +107,28 @@ final public class Task {
             kvp[key] = newValue
         }
     }
+
+    ///Checks that the required overlays in the task are present. We
+    ///allow the parsing of a file that is missing some overlays since
+    ///those overlays may not be required for the present task.
+    public func checkRequiredOverlays() throws {
+            if let requiredOverlays_v = self["required-overlays"] {
+                guard let requiredOverlays = requiredOverlays_v.vector else {
+                    fatalError("Non-vector \(requiredOverlays_v)")
+                }
+                nextSet: for overlaySet_v in requiredOverlays {
+                    guard let overlaySet = overlaySet_v.vector else {
+                        fatalError("Non-vector \(overlaySet_v)")
+                    }
+                    for overlay_s in overlaySet {
+                        guard let overlay = overlay_s.string else {
+                            fatalError("Non-string \(overlay_s)")
+                        }
+                        if self.appliedOverlays.contains(overlay) { continue nextSet }
+                    }
+                    print("Task \(self.qualifiedName) requires at least one of \(overlaySet.map() {$0.string}) but it was not applied.  Applied overlays: \(self.appliedOverlays)")
+                    throw PackageError.RequiredOverlayNotPresent(overlaySet.map() {$0.string!})
+                }
+            }
+    }
 }

--- a/tests/model/PackageTests.swift
+++ b/tests/model/PackageTests.swift
@@ -221,7 +221,8 @@ class PackageTests: Test {
     static func testRequireOverlays() throws {
         let filepath = "./tests/collateral/require_overlays.atpkg"
         do {
-            let _ = try Package(filepath: filepath, overlay: [], focusOnTask: nil)
+            let p = try Package(filepath: filepath, overlay: [], focusOnTask: nil)
+            try p.tasks["build"]?.checkRequiredOverlays()
             print("Overlays were not required")
             try test.assert(false)
         }


### PR DESCRIPTION
It is inappropriate to check for required-overlays at parse-time,
because we may not be interested in the task with the required-overlays.

Specifically, a case arose where a build task required linux/macosx
overlays, but a clean task did not.  However, the user was required to
run clean with the platform overlay for the (unused) build task to be
valid.

The resolution here is to move the required overlays check to a separate
API.  The downside here is that callers have to opt-in to this behavior.

An alternate design would be to intercept this in the task subscript,
but that was considered too invasive.

Resolves https://github.com/AnarchyTools/atbuild/issues/66

Companion PR to https://github.com/AnarchyTools/atbuild/pull/79
