### PR TITLE
Silence some warnings

### DIFF
--- a/src/Package.swift
+++ b/src/Package.swift
@@ -327,7 +327,9 @@ final public class Package {
         //warn about unused global overlays
         for requestedOverlay in requestedGlobalOverlays {
             if !usedGlobalOverlays.contains(requestedOverlay) {
-                print("Warning: overlay \(requestedOverlay) had no effect on package \(name)")
+                if !requestedOverlay.hasPrefix("atbuild.") {
+                    print("Warning: overlay \(requestedOverlay) had no effect on package \(name)")
+                }
             }
         }
 


### PR DESCRIPTION
We have overlays that are set automatically by atbuild now, it is
expected that they won't have an effect across every task.
