### PR TITLE
Add only-platforms

### DIFF
--- a/src/Task.swift
+++ b/src/Task.swift
@@ -39,18 +39,22 @@ final public class Task {
 
     private var kvp: [String:ParseValue]
 
+    public var onlyPlatforms: [String] = []
+
     public enum Option: String {
         case Tool = "tool"
         case UseOverlays = "use-overlays"
         case Overlays = "overlays"
         case Dependencies = "dependencies"
+        case OnlyPlatforms = "only-platforms"
 
         public static var allOptions: [Option] {
             return [
                     Tool,
                     UseOverlays,
                     Overlays,
-                    Dependencies
+                    Dependencies,
+                    OnlyPlatforms
             ]
         }
     }
@@ -97,6 +101,14 @@ final public class Task {
         if let values = kvp[Option.Dependencies.rawValue]?.vector {
             for value in values {
                 if let dep = value.string { self.dependencies.append(dep) }
+            }
+        }
+
+        if let onlyPlatforms = kvp[Option.OnlyPlatforms.rawValue] {
+            guard let o = onlyPlatforms.vector else { fatalError("Non-vector \(Option.OnlyPlatforms.rawValue) \(onlyPlatforms)")}
+            for o in o {
+                guard case .StringLiteral(let platform) = o else { fatalError("Non-string \(Option.OnlyPlatforms.rawValue) \(o)")}
+                self.onlyPlatforms.append(platform)
             }
         }
     }

--- a/tests/collateral/only-platforms.atpkg
+++ b/tests/collateral/only-platforms.atpkg
@@ -1,0 +1,18 @@
+;; This is the most basic of sample files.
+
+(package
+  :name "basic"
+  :version "0.1.0-dev"
+  
+  :tasks {
+    :build {
+      :tool "lldb-build"
+      :name "json-swift"
+      :output-type "lib" 
+      :sources ["src/**.swift" "lib/**.swift"]
+      :only-platforms ["linux" "osx"]
+    }
+  }
+)
+
+; End of the sample.

--- a/tests/model/PackageTests.swift
+++ b/tests/model/PackageTests.swift
@@ -27,7 +27,8 @@ class PackageTests: Test {
         PackageTests.testImportPaths,
         PackageTests.testChainedImportOverlays,
         PackageTests.nonVectorImport,
-        PackageTests.testRequireOverlays
+        PackageTests.testRequireOverlays,
+        PackageTests.testOnlyPlatforms
 
     ]
 
@@ -243,5 +244,13 @@ class PackageTests: Test {
         if let _ = try? Package(filepath: filepath, overlay: [], focusOnTask: nil) {
             try test.assert(false) //no diagnostic
         }
+    }
+
+    static func testOnlyPlatforms() throws {
+        let filepath = Path("tests/collateral/only-platforms.atpkg")
+
+        let p = try Package(filepath: filepath, overlay: [], focusOnTask: nil)
+        guard let task = p.tasks["build"] else { fatalError("No build task")}
+        try test.assert(task.onlyPlatforms == ["linux","osx"])
     }
 }


### PR DESCRIPTION
This is a new task-level property to allow the skipping of tasks on platforms other than the ones specified
