### PR TITLE
atpkg support for binary atpm

### DIFF
--- a/src/Binary.swift
+++ b/src/Binary.swift
@@ -1,0 +1,52 @@
+// Copyright (c) 2016 Anarchy Tools Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import atfoundation
+
+///A "channel" of releases, such as `stable`, `linux`, `osx-framework`, `swift3`, etc.
+public struct BinaryChannel {
+    public let name: String
+    public let versions: [BinaryVersion]
+
+    init(name: String, versions: [BinaryVersion]) {
+        self.name = name
+        self.versions = versions
+    }
+
+    static func parse(_ pv: ParseValue) -> [BinaryChannel] {
+        var arr : [BinaryChannel] = []
+        guard case .Map(let map) = pv else { fatalError("Non-map binary channels")}
+        for (channel,cm) in map {
+            guard case .Map(let channelMap) = cm else {fatalError("Non-map for channel \(channel)")}
+            var channelArray: [BinaryVersion] = []
+            for(version, vm) in channelMap {
+                guard case .Map(let versionMap) = vm else { fatalError("Non-map for version \(channel).\(version)")}
+                guard let u = versionMap["url"] else {fatalError("No url for binary version \(version)")}
+                guard case .StringLiteral(let us) = u else { fatalError("Non-string value \(u) for url")}
+                let url = URL(string: us)
+                let version = BinaryVersion(version: version, url: url)
+                channelArray.append(version)
+            }
+            let bc = BinaryChannel(name: channel, versions: channelArray)
+            arr.append(bc)
+        }
+        return arr
+    }
+}
+
+///A pointer to an individual binary release tarball
+public struct BinaryVersion {
+    public let version: String
+    public let url: URL
+}

--- a/src/parsing/Tokenization.swift
+++ b/src/parsing/Tokenization.swift
@@ -56,14 +56,14 @@ func isValidIdentifierSignalCharacter(c: Character?) -> Bool {
     guard let c = c else {
         return false
     }
-    return Charset.isLetter(character: c)
+    return Charset.isLetter(character: c) || Charset.isNumberDigit(character: c)
 }
 
 func isValidIdenitifierCharacter(c: Character?) -> Bool {
     guard let c = c else {
         return false
     }
-    return Charset.isLetter(character: c) || c == "-" || c == "." || c == "/"
+    return Charset.isLetter(character: c) || Charset.isNumberDigit(character: c) ||  c == "-" || c == "." || c == "/"
 }
 
 func isWhitespace(c: Character?) -> Bool {

--- a/tests/collateral/binary-manifest.atpkg
+++ b/tests/collateral/binary-manifest.atpkg
@@ -1,0 +1,19 @@
+(package
+:name "DummyBinary"
+
+:binaries {
+    :channels {
+        :linux {
+            :1.0 {
+                :url "https://github.com/AnarchyTools/dummyBinaryPackage/releases/download/0.1/linux.tar.xz"
+            }
+        }
+        :osx {
+            :1.0 {
+                :url "https://github.com/AnarchyTools/dummyBinaryPackage/releases/download/0.1/osx.tar.xz"
+            }
+        }
+    }
+}
+
+)

--- a/tests/collateral/use-binary.atpkg
+++ b/tests/collateral/use-binary.atpkg
@@ -1,0 +1,25 @@
+;; Copyright (c) 2016 Anarchy Tools Contributors.
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;   http:;;www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(package
+  :name "use-binary"
+
+  :external-packages [
+    {
+      :url "https://raw.githubusercontent.com/AnarchyTools/dummyBinaryPackage/master/manifest.atpkg"
+      :version [">=1.0"]
+      :channels ["osx"]
+    }
+  ]
+)


### PR DESCRIPTION
See https://github.com/AnarchyTools/atpm/issues/1

This commit adds
- Dependency type to ExternalDependency, to distinguish between Git and Manifest types
  This design was settled on after looking at several, including autodetecting git (which is possible via git ls-remote)
  However, manifest ExternalDependency is quite different than Git ExternalDependency for several reasons (including the use of channels)
- Channels, which are essentially like micropackages inside a package.  A channel lets us say "stable" "beta" "linux" "osx" "swift2.2" etc.  All releases are part of a channel.  It would be possible to use separate manifests for each channel, but this would require the use of multiple manifests for basic osx/linux packages, which is undesireable
- Tokens can now start with numbers, which is important, as we now have syntax where `:1.0 { :url "https://example.com/some/tarball.xz"}` is used to define where some version can be located
